### PR TITLE
Upgrade boot-reload version

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -2,7 +2,7 @@
  :source-paths   #{"src/cljs" "src/clj"}
  :resource-paths #{"resources"}
  :dependencies '[[adzerk/boot-cljs "1.7.228-1" :scope "test"]
-                 [adzerk/boot-reload "0.4.5" :scope "test"]
+                 [adzerk/boot-reload "0.4.12" :scope "test"]
 
                  [adzerk/boot-cljs-repl   "0.3.0" :scope "test"]
                  [com.cemerick/piggieback "0.2.1"  :scope "test"]


### PR DESCRIPTION
I ran into an error following the instructions in the readme:

```
clojure.lang.ExceptionInfo: template already refers to: #'boot.core/template in namespace: adzerk.boot-reload
data: {:file "adzerk/boot_reload.clj", :line 1}
```

Upgrading the boot-reload dependency fixed the issue for me.
